### PR TITLE
Reconstruct OBC-exterior h halo for exact restart

### DIFF
--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -467,41 +467,37 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
     ! Update OBC ramp value as function of time
     call update_OBC_ramp(Time_local, CS%OBC, US)
 
-    ! === OBC-exterior h fix: rebuild the zero-gradient OBC-exterior h halo, which is ===
-    ! not reconstructed bit-for-bit across an exact restart. vertvisc_coef projects
-    ! thickness outward across OBCs and reads this exterior h/dz, so a stale/inconsistent
-    ! exterior value seeds a last-bit velocity difference that breaks exact restart.
-    ! Two passes (E/W exterior columns, then N/S exterior rows) so diagonal corner cells
-    ! trace back to the bit-perfect interior h rather than a stale exterior cell.
-    ! Pass 1: E/W segments -- fill exterior column from the first interior column.
-    do n=1,CS%OBC%number_of_segments
-      segment => CS%OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (.not. segment%is_E_or_W) cycle
-      I = segment%HI%IsdB
-      do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed
-        if (segment%direction == OBC_DIRECTION_W) then
-          h(I,j,k)   = h(I+1,j,k)
-        elseif (segment%direction == OBC_DIRECTION_E) then
-          h(I+1,j,k) = h(I,j,k)
+    ! === OBC-exterior h fix (minimal): the OBC-exterior h halo is not reconstructed
+    ! bit-for-bit across an exact restart, and vertvisc_coef reads it (zero-gradient
+    ! projection across OBCs), seeding a last-bit velocity divergence. Rebuild it here with a
+    ! single in-place zero-gradient fill over all segments: copy the first interior thickness
+    ! into the exterior ghost cell. u-points (E/W) and v-points (N/S) only read same-row /
+    ! same-column neighbours, never the diagonal corner, so no corner handling is needed.
+    if (associated(CS%OBC)) then
+      do n=1,CS%OBC%number_of_segments
+        segment => CS%OBC%segment(n)
+        if (.not. segment%on_pe) cycle
+        if (segment%is_E_or_W) then
+          I = segment%HI%IsdB
+          do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed
+            if (segment%direction == OBC_DIRECTION_W) then
+              h(I,j,k)   = h(I+1,j,k)
+            elseif (segment%direction == OBC_DIRECTION_E) then
+              h(I+1,j,k) = h(I,j,k)
+            endif
+          enddo ; enddo
+        elseif (segment%is_N_or_S) then
+          J = segment%HI%JsdB
+          do k=1,nz ; do i=segment%HI%isd,segment%HI%ied
+            if (segment%direction == OBC_DIRECTION_S) then
+              h(i,J,k)   = h(i,J+1,k)
+            elseif (segment%direction == OBC_DIRECTION_N) then
+              h(i,J+1,k) = h(i,J,k)
+            endif
+          enddo ; enddo
         endif
-      enddo ; enddo
-    enddo
-    ! Pass 2: N/S segments -- fill exterior row; corner cells pick up the E/W-filled
-    ! (interior-traced) column from pass 1.
-    do n=1,CS%OBC%number_of_segments
-      segment => CS%OBC%segment(n)
-      if (.not. segment%on_pe) cycle
-      if (.not. segment%is_N_or_S) cycle
-      J = segment%HI%JsdB
-      do k=1,nz ; do i=segment%HI%isd,segment%HI%ied
-        if (segment%direction == OBC_DIRECTION_S) then
-          h(i,J,k)   = h(i,J+1,k)
-        elseif (segment%direction == OBC_DIRECTION_N) then
-          h(i,J+1,k) = h(i,J,k)
-        endif
-      enddo ; enddo
-    enddo
+      enddo
+    endif
     ! === end OBC-exterior h fix ===
 
     do k=1,nz ; do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB

--- a/src/core/MOM_dynamics_split_RK2.F90
+++ b/src/core/MOM_dynamics_split_RK2.F90
@@ -58,6 +58,8 @@ use MOM_interface_heights,     only : thickness_to_dz, find_col_avg_SpV
 use MOM_lateral_mixing_coeffs, only : VarMix_CS
 use MOM_MEKE_types,            only : MEKE_type
 use MOM_open_boundary,         only : ocean_OBC_type, radiation_open_bdry_conds
+use MOM_open_boundary,         only : OBC_segment_type, OBC_DIRECTION_E, OBC_DIRECTION_W
+use MOM_open_boundary,         only : OBC_DIRECTION_N, OBC_DIRECTION_S
 use MOM_open_boundary,         only : open_boundary_zero_normal_flow, open_boundary_query
 use MOM_open_boundary,         only : open_boundary_test_extern_h, update_OBC_ramp
 use MOM_open_boundary,         only : copy_thickness_reservoirs
@@ -417,6 +419,8 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
   integer :: i, j, k, is, ie, js, je, Isq, Ieq, Jsq, Jeq, nz
   integer :: cont_stencil, obc_stencil, vel_stencil
   integer :: cor_stencil
+  integer :: n                                         ! OBC segment loop index (OBC-exterior h fix)
+  type(OBC_segment_type), pointer :: segment => NULL() ! OBC segment (OBC-exterior h fix)
 
   is  = G%isc  ; ie  = G%iec  ; js  = G%jsc  ; je  = G%jec ; nz = GV%ke
   Isq = G%IscB ; Ieq = G%IecB ; Jsq = G%JscB ; Jeq = G%JecB
@@ -462,6 +466,43 @@ subroutine step_MOM_dyn_split_RK2(u_inst, v_inst, h, tv, visc, Time_local, dt, f
 
     ! Update OBC ramp value as function of time
     call update_OBC_ramp(Time_local, CS%OBC, US)
+
+    ! === OBC-exterior h fix: rebuild the zero-gradient OBC-exterior h halo, which is ===
+    ! not reconstructed bit-for-bit across an exact restart. vertvisc_coef projects
+    ! thickness outward across OBCs and reads this exterior h/dz, so a stale/inconsistent
+    ! exterior value seeds a last-bit velocity difference that breaks exact restart.
+    ! Two passes (E/W exterior columns, then N/S exterior rows) so diagonal corner cells
+    ! trace back to the bit-perfect interior h rather than a stale exterior cell.
+    ! Pass 1: E/W segments -- fill exterior column from the first interior column.
+    do n=1,CS%OBC%number_of_segments
+      segment => CS%OBC%segment(n)
+      if (.not. segment%on_pe) cycle
+      if (.not. segment%is_E_or_W) cycle
+      I = segment%HI%IsdB
+      do k=1,nz ; do j=segment%HI%jsd,segment%HI%jed
+        if (segment%direction == OBC_DIRECTION_W) then
+          h(I,j,k)   = h(I+1,j,k)
+        elseif (segment%direction == OBC_DIRECTION_E) then
+          h(I+1,j,k) = h(I,j,k)
+        endif
+      enddo ; enddo
+    enddo
+    ! Pass 2: N/S segments -- fill exterior row; corner cells pick up the E/W-filled
+    ! (interior-traced) column from pass 1.
+    do n=1,CS%OBC%number_of_segments
+      segment => CS%OBC%segment(n)
+      if (.not. segment%on_pe) cycle
+      if (.not. segment%is_N_or_S) cycle
+      J = segment%HI%JsdB
+      do k=1,nz ; do i=segment%HI%isd,segment%HI%ied
+        if (segment%direction == OBC_DIRECTION_S) then
+          h(i,J,k)   = h(i,J+1,k)
+        elseif (segment%direction == OBC_DIRECTION_N) then
+          h(i,J+1,k) = h(i,J,k)
+        endif
+      enddo ; enddo
+    enddo
+    ! === end OBC-exterior h fix ===
 
     do k=1,nz ; do j=G%jsd,G%jed ; do I=G%IsdB,G%IedB
       u_old_rad_OBC(I,j,k) = u_av(I,j,k)


### PR DESCRIPTION
## Summary

Fixes a bit-for-bit exact-restart failure in regional/OBC configurations: with open boundaries enabled, the CIME `ERS` exact-restart test (`COMPARE_base_rest`) fails, while the same case with `OBC_NUMBER_OF_SEGMENTS = 0` restarts bit-for-bit.

## Root cause

Across an exact restart, the **OBC-exterior `h` halo** (the ghost ring just outside open-boundary segments) is not reconstructed bit-for-bit. The interior thickness restarts perfectly, but the exterior ghost cells come back different (~cm-scale, not roundoff): the restart file stores only the computational domain, and the existing thickness-reservoir restart path (`h_res_x`/`h_res_y`, gated by `use_h_res`) does not restore the value the friction solve needs.

The prognostic exact-restart breaker is in **`vertvisc`** (the velocity solve), in the **`DIRECT_STRESS` body-force block**. With `DIRECT_STRESS = True`, the wind stress is applied as a body force over the top `HMIX_STRESS` of fluid; to distribute it, `vertvisc` computes the velocity-face thickness

```fortran
h_a = 0.5 * (h(i,j,k) + h(i+1,j,k)) + h_neglect   ! L698 (u-points),  L918 (v-points)
hfr = 1.0 ; if ((zDS+h_a) > Hmix) hfr = (Hmix - zDS) / h_a
u(I,j,k) = u(I,j,k) + I_Hmix * hfr * stress
```

At an OBC face one of those two cells is the exterior ghost cell, so `h_a` reads the **non-reproducible exterior `h` with no OBC projection** at all. The stale value perturbs `hfr` and hence the surface velocity, seeding a last-bit divergence that grows over the run.

Note `vertvisc_coef` **does** carry a zero-gradient OBC projection for its coupling coefficient, and it works correctly (the coefficients `a_u`/`a_v` were bit-perfect in the probes) — it was not the culprit. The unguarded read is in `vertvisc`'s direct-stress path, which the projection never covered.

### Isolation / confirmation (regional `ERS_Ld9`, 4 OBC segments)

- Collective-checksum probes at the first post-restart predictor step: every input to `vertvisc` matched across the two restart legs **except** the comp+1 (OBC-exterior) ring of `h`; `up` matched *going into* `vertvisc` and differed *coming out* — consistent with the perturbation happening **inside** `vertvisc` (the direct-stress block), not in the coefficient.
- **`DIRECT_STRESS = False` on unfixed code** → `mom6.h.native`, `mom6.h.sfc`, and `cpl.hi` are **bit-for-bit identical** (the prognostic leak is gone). Only tiny `mom6.h.z` *diagnostic* diffs remain (`Kv_u` ~1% normalized, velocities ~1e-7), because the exterior `h` is still unreconstructed and is also read by z-remap / coefficient diagnostics — a second, diagnostic-only consumer that does not feed back into the prognostic state.
- Leak is **independent of `HARMONIC_VISC`** (it's in `vertvisc`, not `vertvisc_coef`'s averaging branch).
- **Both E/W and N/S** boundaries leak (reconstructing only E/W halves the divergence); diagonal **corners are irrelevant** (`vertvisc` reads only same-row / same-column neighbours, never the corner).

## Fix

Rebuild the exterior `h` with a **single in-place zero-gradient fill** over all OBC segments at the top of `step_MOM_dyn_split_RK2`, right after `update_OBC_ramp`: copy the first interior thickness into the exterior ghost cell (E/W exterior columns, N/S exterior rows). Fixing the **value** upstream makes the exterior `h` reproducible before *any* consumer reads it, so it closes both the prognostic direct-stress path and the diagnostic paths at once — unlike a `DIRECT_STRESS = False` workaround, which would fix only the prognostic state (and changes the physics).

~16 lines; no thickness-reservoir dependency, no two-pass ordering, no corner special-casing.

## Verification

Regional CESM G-compset case, `ERS_Ld9`, 4 Flather/Orlanski/nudged OBC segments:

- `COMPARE_base_rest` passes **bit-for-bit**, including `mom6.h.z`.
- Negative controls: the pristine pre-fix code (SourceMod over the fixed tree) reproduces the failure; `DIRECT_STRESS = False` on unfixed code isolates the direct-stress block as the prognostic leak.

## Notes

- Alternative fix locations for maintainer review: add an OBC zero-gradient guard to `vertvisc`'s direct-stress thickness average (and any other unguarded consumer such as the z-remap diagnostic), or ensure the exterior `h` is properly restarted/reconstructed at init (e.g. via the thickness reservoirs). Reconstructing the value upstream (this PR) closes all consumers at once.
- Targets `cleaned_marbl_generic_tracers` so it stacks on the regional/MARBL line currently in use.
